### PR TITLE
Make it work on stable rust 1.53

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -15,9 +15,10 @@ pub struct Executor<F, const N: usize> {
 }
 
 impl<F: Future, const N: usize> Executor<F, N> {
+    const SAMPLE: Option<F> = None;
     pub fn new() -> Self {
         Executor {
-            task_queue: [None; N],
+            task_queue: [Self::SAMPLE; N],
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(const_generics)]
-#![feature(const_in_array_repeat_expressions)]
-
 use std::rc::Rc;
 use std::time::Instant;
 use structopt::StructOpt;


### PR DESCRIPTION
 Feature `const_in_array_repeat_expressions` have been removed due to ambiguous drop order of `?Sised` objects and other whatever reasons [link](https://github.com/rust-lang/rust/issues/49147).

And workaround is to make a constant for the value:
```Rust
const SAMPLE: Option<F> = None;
pub fn new() -> Self {
    Executor {
        task_queue: [Self::SAMPLE; N],
    }
}
```

   And below the using 0 as `*const ()` is probably safe, but better to use ptr::null() and clippy also has style lint for this situation [zero_ptr](https://rust-lang.github.io/rust-clippy/master/#zero_ptr)

   Value of NULL is guaranteed by the standard to be 0. In practice, this particular feature was used in the first PDP machines, if I am not mistaken. if (ptr) and if (ptr == 0) and if (ptr == NULL) are always and everywhere equivalent https://twitter.com/typesanitizer/status/1333171905872891904

p.s.: I'm good at bad names :x 